### PR TITLE
助詞のlistではなく、助詞のsetのlistになってしまっている点の修正

### DIFF
--- a/asapy/parse/semantic/Sematter.py
+++ b/asapy/parse/semantic/Sematter.py
@@ -62,7 +62,7 @@ class Sematter():
         for chunk in chunks:
             for morph in chunk.morphs:
                 if '格助詞' in morph.pos and chunk.part in {'に', 'へ'}:
-                    chunk.another_parts = [{'に', 'へ'} - set(chunk.part)]
+                    chunk.another_parts = list({'に', 'へ'} - set(chunk.part))
                 elif '係助詞' in morph.pos:
                     chunk.another_parts = ['が', 'を']
                 else:


### PR DESCRIPTION
・今の実装の問題点
`chunk.another_parts = [{'に', 'へ'} - set(chunk.part)]`
において、例えば `set(chunk.part)` が `{'に'}`であった場合、
`chunk.another_parts`が`[{'へ'}]`という風になり、文字のリストではなく文字のセットのリストになってしまいます。

・影響を及ぼしている箇所
asapy/parse/semantic/Calculate.pyの`__getPartSimilar`関数内、117行目において、
`elif part in chunk.another_parts: similar = 1.0`
とありますが、partは単なる文字(例えば'に'など)であるため、もし`chunk.another_parts`が`[{'に'}]`であった場合、
`'に' in [{'に'}]`
はfalseになってしまいます。従って、正しくsimilarが計算できません。

・修正方法
`chunk.another_parts = list({'に', 'へ'} - set(chunk.part))`
とすることでsetをlistに変換するようにしました。