### PR TITLE
mecabに"名詞,固有名詞,地域"という出力が存在しないため、場所判定がされない不具合の修正

### DIFF
--- a/asapy/parse/feature/Tagger.py
+++ b/asapy/parse/feature/Tagger.py
@@ -143,7 +143,7 @@ class Tagger():
                         category.append("数値")
                 if morph.pos in ["名詞,固有名詞,人名", "名詞,接尾,人名"]:
                     category.append("人")
-                elif morph.pos in ["名詞,固有名詞,地域", "名詞,接尾,地域"]:
+                elif morph.pos in ["名詞,固有名詞,地域,一般", "名詞,固有名詞,地域,国", "名詞,接尾,地域"]:
                     category.append("場所")
                 elif morph.pos in ["名詞,固有名詞,組織"]:
                     category.append("組織")


### PR DESCRIPTION
・今の実装の問題点
`elif morph.pos in ["名詞,固有名詞,地域", "名詞,接尾,地域"]:`
となっていますが、mecabの出力には"名詞,固有名詞,地域"というPOSタグは存在しないので、`morph.pos in ["名詞,固有名詞,地域"]`がtrueになることがありません。
(http://www.unixuser.org/~euske/doc/postag/ など参照)

・影響を及ぼしている箇所
上の問題点により、categorys.jsonに登録されていない地名について場所判定がされません。具体的には、「熱海」などの地名は現状の実装において場所判定がされず、categoryが空欄になってしまいます。

・修正方法
mecabの場所を表す名詞に関するPOSタグは`"名詞,固有名詞,地域,一般", "名詞,固有名詞,地域,国"`の2つですので、
`elif morph.pos in ["名詞,固有名詞,地域,一般", "名詞,固有名詞,地域,国", "名詞,接尾,地域"]:`
とすることで正しく場所の判定がされるようにしました。