### PR TITLE
「飲んだ」など、過去の助動詞「だ」を接尾語に持つものが過去形と判定されない不具合の修正

### DIFF
--- a/asapy/parse/feature/Tagger.py
+++ b/asapy/parse/feature/Tagger.py
@@ -60,6 +60,13 @@ class Tagger():
         isPast = False
         if chunk.morphs:
             isPast = bool([morph for morph in chunk.morphs if re.search(r"助動詞", morph.pos) and morph.base in ["た", "き", "けり"]])
+            if not isPast:
+                before_morph = ""
+                for morph in chunk.morphs:
+                    if re.search(r"助動詞", morph.pos) and morph.base == "だ":
+                        if "連用" in before_morph.ctype:
+                            isPast = True
+                    before_morph = morph
         if isPast:
             tense = "PAST"
         else:


### PR DESCRIPTION
・今の実装の問題点
`isPast = bool([morph for morph in chunk.morphs if re.search(r"助動詞", morph.pos) and morph.base in ["た", "き", "けり"]])`
の過去の助動詞一覧に「だ」がないため、「飲んだ」等の語が過去形と判断されません。

・影響を及ぼしている箇所
現状時制を用いる箇所はあまりないので、過去形と判断できない以上のデメリットはあまりなさそうです。

・修正方法
単に「だ」を過去の助動詞のリストに加えるだけだと断定の「だ」と混同してしまい、例えば「私は学生だ」などという文章も過去形と判断してしまいます。
そこで、接続の違いを用いました。
断定の助動詞「だ」は体言などと接続するのに対し、過去の助動詞「だ」は連用形接続です。
従って、1つ前の形態素についてctypeを調べることによって過去の助動詞「だ」を判定するようにしました。
しかし、1つ前の形態素を保持しておく必要があるために冗長な処理になってしまったのが欠点です。