### PR TITLE
Add shebang and file encoding specification

### DIFF
--- a/asapy/main.py
+++ b/asapy/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import time

--- a/asapy/main.py
+++ b/asapy/main.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 import time
 from ASA import ASA
 


### PR DESCRIPTION
@Takeuchi-Lab-LM
I would like to recommend you to insert a shebang `#!/usr/bin/env python3`  to prevent the error `import: unable to open X server` ([cf.](https://qiita.com/dendensho/items/038627cdece41905f08b)), and to add `# -*- coding: utf-8 -*-` in line 2 to specify the file encoding.

I'm running your script on Ubuntu 18.04 as a Windows Subsystem for Linux.