### PR TITLE
fix: 不要な書き込み権限を除去する

### DIFF
--- a/asapy/dict/yaml2json.py
+++ b/asapy/dict/yaml2json.py
@@ -4,63 +4,63 @@ import json
 
 tmp = {}
 '''
-with open("NounTest.yaml", 'r+') as f:
+with open("NounTest.yaml", 'r') as f:
     tmp = yaml.load(f)
 with open("NounTest.json", 'w') as f:
     json.dump(tmp, f)
 
-with open("filters.yaml", 'r+') as f:
+with open("filters.yaml", 'r') as f:
     tmp = yaml.load(f)
 with open("filters.json", 'w') as f:
     json.dump(tmp, f)
 
-with open("new_categorys.yaml", 'r+') as f:
+with open("new_categorys.yaml", 'r') as f:
     tmp = yaml.load(f)
 with open("new_categorys.json", 'w') as f:
     json.dump(tmp, f)
 
-with open("categorys.yaml", 'r+') as f:
+with open("categorys.yaml", 'r') as f:
     tmp = yaml.load(f)
 with open("categorys.json", 'w') as f:
     json.dump(tmp, f)
 
-with open("frames.yaml", 'r+') as f:
+with open("frames.yaml", 'r') as f:
     tmp = yaml.load(f)
 with open("frames.json", 'w') as f:
     json.dump(tmp, f)
 
-with open("new_frames.yaml", 'r+') as f:
+with open("new_frames.yaml", 'r') as f:
     tmp = yaml.load(f)
 with open("new_frames.json", 'w') as f:
     json.dump(tmp, f)
 
-with open("ccharts.yaml", 'r+') as f:
+with open("ccharts.yaml", 'r') as f:
     tmp = yaml.load(f)
 with open("ccharts.json", 'w') as f:
     json.dump(tmp, f)
 
-with open("idioms.yaml", 'r+') as f:
+with open("idioms.yaml", 'r') as f:
     tmp = yaml.load(f)
 with open("idioms.json", 'w') as f:
     json.dump(tmp, f)
 
-with open("new_frames2.yaml", 'r+') as f:
+with open("new_frames2.yaml", 'r') as f:
     tmp = yaml.load(f)
 with open("new_frames2.json", 'w') as f:
     json.dump(tmp, f)
 
-with open("compoundPredicates.yaml", 'r+') as f:
+with open("compoundPredicates.yaml", 'r') as f:
     tmp = yaml.load(f)
 with open("compoundPredicates.json", 'w') as f:
     json.dump(tmp, f)
 
-with open("verbs.yaml", 'r+') as f:
+with open("verbs.yaml", 'r') as f:
     tmp = yaml.load(f)
 with open("verbs.json", 'w') as f:
     json.dump(tmp, f)
 '''
 
-with open("new_argframes.yaml", 'r+') as f:
+with open("new_argframes.yaml", 'r') as f:
     tmp = yaml.load(f)
 with open("new_argframes.json", 'w') as f:
     json.dump(tmp, f)

--- a/asapy/load/LoadJson.py
+++ b/asapy/load/LoadJson.py
@@ -21,7 +21,7 @@ class LoadJson():
     def __loadJson(self, jsonpath: str) -> dict:
         dirname = os.path.dirname(__file__)
         abspath = os.path.abspath(dirname)
-        with open(os.path.join(abspath)+'/../'+jsonpath, 'r+') as f:
+        with open(os.path.join(abspath)+'/../'+jsonpath, 'r') as f:
             return json.load(f)
 
     def __loadFrames(self, dic, jsonpath):


### PR DESCRIPTION
`r`ではなく`r+`を使うと先頭から書き込みも行えるモードでファイルが開かれるが、
自分が見る限り書き込みをしている箇所が見つからない。
書き込み可能なようにすると以下のように読み込み専用ファイルシステムを使うとエラーになる。

~~~
"errorMessage": "[Errno 30] Read-only file system: '/asa-server/python_asa/asapy/load/../dict/new_argframes.json'",
"errorType": "OSError",
~~~

よって書き込みを行わない場合は読み込み専用で開いた方が適切だと考える。